### PR TITLE
move python-semantic-release to dev dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-python-semantic-release = "^7.32.2"
 requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
@@ -15,6 +14,7 @@ coverage = "^6.5.0"
 pytest = "^7.2.0"
 pytest-mock = "^3.10.0"
 python-dotenv = "^0.21.0"
+python-semantic-release = "^7.32.2"
 vcrpy = "^4.2.1"
 
 [build-system]


### PR DESCRIPTION
Currently installing the mailerlite SDK, also includes python-semantic-release.  This causes a lot of unnecessary dependencies to be installed when getting the package.