### PR TITLE
fix: Incorrect subscribers param filtering

### DIFF
--- a/mailerlite/sdk/subscribers.py
+++ b/mailerlite/sdk/subscribers.py
@@ -17,13 +17,13 @@ class Subscribers(object):
         Returns a list of all subscribers.
         Ref: https://developers.mailerlite.com/docs/subscribers.html#list-all-subscribers
 
-        :param **kwargs: dict You can pass additional arguments - page, limit or filter by status
+        :param **kwargs: dict You can pass additional arguments - cursor, limit or filter by status
         :raises: :class: `TypeError` : Got an unknown argument
         :return: JSON array
         :rtype: dict
         """
 
-        available_params = ["filter", "limit", "page"]
+        available_params = ["filter", "limit", "cursor"]
 
         params = locals()
         query_params = {}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest>=7.2.0
 coverage>=6.5.0
 black>=22.10.0
 pytest-mock>=3.10.0
+python-dotenv==1.0.0

--- a/tests/subscribers_test.py
+++ b/tests/subscribers_test.py
@@ -95,12 +95,18 @@ class TestSubscribers:
         "tests/vcr_cassettes/subscribers-list.yml", filter_headers=["Authorization"]
     )
     def test_list_of_all_subscribers_should_be_returned(self, subscriber_keys):
-        response = self.client.subscribers.list(limit=10, page=1)
+        response = self.client.subscribers.list(limit=10, cursor="abc123")
 
         assert isinstance(response, dict)
         assert isinstance(response["data"], list)
         assert isinstance(response["data"][0], dict)
         assert set(subscriber_keys).issubset(response["data"][0].keys())
+
+    def test_list_of_all_subscribers_raises_exception_with_invalid_params(
+        self,
+    ):
+        with pytest.raises(TypeError):
+            self.client.subscribers.list(limit=10, page=1)
 
     def test_given_invalid_email_address_when_calling_create_then_create_subscriber_will_fail(
         self,

--- a/tests/vcr_cassettes/subscribers-list.yml
+++ b/tests/vcr_cassettes/subscribers-list.yml
@@ -13,7 +13,7 @@ interactions:
       User-Agent:
       - MailerLite-Python-SDK-Client
     method: GET
-    uri: https://connect.mailerlite.com/api/subscribers?limit=10&page=1
+    uri: https://connect.mailerlite.com/api/subscribers?limit=10&cursor=abc123
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
I couldn't get this api endpoint to actually paginate without using the `cursor` param described in your [API docs](https://developers.mailerlite.com/docs/subscribers.html#list-all-subscribers)