### PR TITLE
fix: Fixed incorrect filtering of subscribers

### DIFF
--- a/mailerlite/sdk/subscribers.py
+++ b/mailerlite/sdk/subscribers.py
@@ -30,7 +30,11 @@ class Subscribers(object):
         for key, val in params["kwargs"].items():
             if key not in available_params:
                 raise TypeError("Got an unknown argument '%s'" % key)
-            query_params[key] = val
+            if key == "filter":
+                for filter_key, filter_value in val.items():
+                    query_params[f"filter[{filter_key}]"] = filter_value
+            else:
+                query_params[key] = val
 
         return self.api_client.request("GET", self.base_api_url, query_params).json()
 


### PR DESCRIPTION
This also fixes [the example from README](https://github.com/mailerlite/mailerlite-python?tab=readme-ov-file#list-all-subscribers).  The code snippet is copied from [mailerlite/sdk/groups.py](https://github.com/mailerlite/mailerlite-python/blob/5d7d3d81d7f9cef948fe0b1d76389dfa090ba772/mailerlite/sdk/groups.py#L31).