### PR TITLE
Conform to API spec for Sub Reads and Updates

### DIFF
--- a/mailerlite/sdk/automations.py
+++ b/mailerlite/sdk/automations.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .lib import format_query_params
 
 
 class Automations(object):
@@ -24,18 +25,7 @@ class Automations(object):
         """
 
         available_params = ["filter", "page", "limit"]
-
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[f"filter[{filter_key}]"] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         print(query_params)
         return self.api_client.request("GET", self.base_api_url, query_params).json()
@@ -65,18 +55,7 @@ class Automations(object):
         """
 
         available_params = ["filter", "page", "limit"]
-
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[f"filter[{filter_key}]"] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request(
             "GET",

--- a/mailerlite/sdk/campaigns.py
+++ b/mailerlite/sdk/campaigns.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .lib import format_query_params
 
 
 class Campaigns(object):
@@ -77,17 +78,7 @@ class Campaigns(object):
 
         available_params = ["filter", "page", "limit"]
 
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[f"filter[{filter_key}]"] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request("GET", self.base_api_url, query_params).json()
 

--- a/mailerlite/sdk/fields.py
+++ b/mailerlite/sdk/fields.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .lib import format_query_params
 
 
 class Fields(object):
@@ -52,16 +53,7 @@ class Fields(object):
 
         available_params = ["limit", "page", "filter", "sort"]
 
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[f"filter[{filter_key}]"] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request("GET", self.base_api_url, query_params).json()
 

--- a/mailerlite/sdk/forms.py
+++ b/mailerlite/sdk/forms.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .lib import format_query_params
 
 
 class Forms(object):
@@ -20,18 +21,7 @@ class Forms(object):
         """
 
         available_params = ["limit", "page", "filter", "sort"]
-
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[f"filter[{filter_key}]"] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request(
             "GET", f"{self.base_api_url}/{type}", query_params
@@ -101,17 +91,7 @@ class Forms(object):
 
         available_params = ["limit", "page", "filter"]
 
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[filter_key] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request(
             "GET", f"{self.base_api_url}/{form_id}/subscribers", query_params

--- a/mailerlite/sdk/groups.py
+++ b/mailerlite/sdk/groups.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .lib import format_query_params
 
 
 class Groups(object):
@@ -23,16 +24,7 @@ class Groups(object):
 
         available_params = ["list", "limit", "page", "sort", "filter"]
 
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[filter_key] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request("GET", self.base_api_url, query_params).json()
 
@@ -132,18 +124,8 @@ class Groups(object):
             )
 
         available_params = ["filter", "limit", "page"]
+        query_params = format_query_params(available_params, **kwargs)
 
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[f"filter[{filter_key}]"] = filter_value
-            else:
-                query_params[key] = val
-        
         return self.api_client.request(
             "GET",
             f"{self.base_api_url}/{group_id}/subscribers",

--- a/mailerlite/sdk/lib.py
+++ b/mailerlite/sdk/lib.py
@@ -1,0 +1,13 @@
+def format_query_params(available_params, **kwargs):
+
+    query_params = {}
+    for key, val in kwargs.items():
+        if key not in available_params:
+            raise TypeError("Got an unknown argument '%s'" % key)
+        if key == "filter":
+            for filter_key, filter_value in val.items():
+                query_params[f"filter[{filter_key}]"] = filter_value
+        else:
+            query_params[key] = val
+
+    return query_params

--- a/mailerlite/sdk/segments.py
+++ b/mailerlite/sdk/segments.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from .lib import format_query_params
+
 
 class Segments(object):
     # Segments base API uri
@@ -23,13 +25,7 @@ class Segments(object):
 
         available_params = ["limit", "page"]
 
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-            query_params[key] = val
-
+        query_params = format_query_params(available_params, **kwargs)
         return self.api_client.request("GET", self.base_api_url, query_params).json()
 
     def get_subscribers(self, segment_id, **kwargs):
@@ -52,20 +48,12 @@ class Segments(object):
                 f"`segment_id` type is not valid. Expected `int`, got {type(segment_id)}."
             )
 
-        if not isinstance(segment_id, int):
-            raise TypeError("Segment ID are not valid.")
+        available_params = ["filter", "limit", "after", "page"]
 
-        available_params = ["filter", "limit", "after"]
-
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-            query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request(
-            "GET", f"{self.base_api_url}/{segment_id}", query_params
+            "GET", f"{self.base_api_url}/{segment_id}/subscribers", query_params
         ).json()
 
     def update(self, segment_id, name):

--- a/mailerlite/sdk/subscribers.py
+++ b/mailerlite/sdk/subscribers.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import re
 
+from .lib import format_query_params
+
 
 class Subscribers(object):
     # Subscribers base API uri
@@ -27,17 +29,7 @@ class Subscribers(object):
         """
 
         available_params = ["filter", "limit", "page"]
-
-        params = locals()
-        query_params = {}
-        for key, val in params["kwargs"].items():
-            if key not in available_params:
-                raise TypeError("Got an unknown argument '%s'" % key)
-            if key == "filter":
-                for filter_key, filter_value in val.items():
-                    query_params[f"filter[{filter_key}]"] = filter_value
-            else:
-                query_params[key] = val
+        query_params = format_query_params(available_params, **kwargs)
 
         return self.api_client.request("GET", self.base_api_url, query_params).json()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest>=7.2.0
 coverage>=6.5.0
 black>=22.10.0
 pytest-mock>=3.10.0
+python-dotenv>=1.0.1


### PR DESCRIPTION
The API Docs specify either an ID or an email are allowed for fetching and updating a subscriber. This client doesn't allow a subscriber_id in either case. I've fixed that.

I attempted to update the test suite to test out the regex and the new control flow, but I discovered that about 40% of the tests are currently failing, so I guess this is a WIP? I've left it alone (I did, however, update the test requirements file as it was missing a dependency).


Fetch: https://developers.mailerlite.com/docs/subscribers.html#fetch-a-subscriber
```
GET https://connect.mailerlite.com/api/subscribers/(:id or :email)
```

https://developers.mailerlite.com/docs/subscribers.html#update-a-subscriber
```
PUT https://connect.mailerlite.com/api/subscribers/(:id)
```

- I've updated the regex to allow an int, and pulled the regexes out of the methods and popped them at the top of the class.
- The 'update' method of subscribers was using the POST, which is also used by the 'create' method, which I've updated to better reflect the API spec.